### PR TITLE
Revert "Re-license" CC BY-SA 4.0 to CC BY-NC-SA 4.0.

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,10 +1,4 @@
-CC-BY-NC-SA-4.0
-
-https://creativecommons.org/licenses/by-nc-sa/4.0/legalcode
-
-Creative Commons Attribution Non Commercial Share Alike 4.0 International
-Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International
-Attribution-NonCommercial-ShareAlike 4.0 International
+Attribution-ShareAlike 4.0 International
 
 =======================================================================
 
@@ -39,7 +33,7 @@ exhaustive, and do not form part of our licenses.
      material not subject to the license. This includes other CC-
      licensed material, or material used under an exception or
      limitation to copyright. More considerations for licensors:
-    wiki.creativecommons.org/Considerations_for_licensors
+     wiki.creativecommons.org/Considerations_for_licensors
 
      Considerations for the public: By using one of our public
      licenses, a licensor grants the public permission to use the
@@ -56,22 +50,22 @@ exhaustive, and do not form part of our licenses.
      Although not required by our licenses, you are encouraged to
      respect those requests where reasonable. More considerations
      for the public:
-    wiki.creativecommons.org/Considerations_for_licensees
+     wiki.creativecommons.org/Considerations_for_licensees
 
 =======================================================================
 
-Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International
-Public License
+Creative Commons Attribution-ShareAlike 4.0 International Public
+License
 
 By exercising the Licensed Rights (defined below), You accept and agree
 to be bound by the terms and conditions of this Creative Commons
-Attribution-NonCommercial-ShareAlike 4.0 International Public License
-("Public License"). To the extent this Public License may be
-interpreted as a contract, You are granted the Licensed Rights in
-consideration of Your acceptance of these terms and conditions, and the
-Licensor grants You such rights in consideration of benefits the
-Licensor receives from making the Licensed Material available under
-these terms and conditions.
+Attribution-ShareAlike 4.0 International Public License ("Public
+License"). To the extent this Public License may be interpreted as a
+contract, You are granted the Licensed Rights in consideration of Your
+acceptance of these terms and conditions, and the Licensor grants You
+such rights in consideration of benefits the Licensor receives from
+making the Licensed Material available under these terms and
+conditions.
 
 
 Section 1 -- Definitions.
@@ -90,7 +84,7 @@ Section 1 -- Definitions.
      and Similar Rights in Your contributions to Adapted Material in
      accordance with the terms and conditions of this Public License.
 
-  c. BY-NC-SA Compatible License means a license listed at
+  c. BY-SA Compatible License means a license listed at
      creativecommons.org/compatiblelicenses, approved by Creative
      Commons as essentially the equivalent of this Public License.
 
@@ -114,7 +108,7 @@ Section 1 -- Definitions.
 
   g. License Elements means the license attributes listed in the name
      of a Creative Commons Public License. The License Elements of this
-     Public License are Attribution, NonCommercial, and ShareAlike.
+     Public License are Attribution and ShareAlike.
 
   h. Licensed Material means the artistic or literary work, database,
      or other material to which the Licensor applied this Public
@@ -128,15 +122,7 @@ Section 1 -- Definitions.
   j. Licensor means the individual(s) or entity(ies) granting rights
      under this Public License.
 
-  k. NonCommercial means not primarily intended for or directed towards
-     commercial advantage or monetary compensation. For purposes of
-     this Public License, the exchange of the Licensed Material for
-     other material subject to Copyright and Similar Rights by digital
-     file-sharing or similar means is NonCommercial provided there is
-     no payment of monetary compensation in connection with the
-     exchange.
-
-  l. Share means to provide material to the public by any means or
+  k. Share means to provide material to the public by any means or
      process that requires permission under the Licensed Rights, such
      as reproduction, public display, public performance, distribution,
      dissemination, communication, or importation, and to make material
@@ -144,13 +130,13 @@ Section 1 -- Definitions.
      public may access the material from a place and at a time
      individually chosen by them.
 
-  m. Sui Generis Database Rights means rights other than copyright
+  l. Sui Generis Database Rights means rights other than copyright
      resulting from Directive 96/9/EC of the European Parliament and of
      the Council of 11 March 1996 on the legal protection of databases,
      as amended and/or succeeded, as well as other essentially
      equivalent rights anywhere in the world.
 
-  n. You means the individual or entity exercising the Licensed Rights
+  m. You means the individual or entity exercising the Licensed Rights
      under this Public License. Your has a corresponding meaning.
 
 
@@ -164,10 +150,9 @@ Section 2 -- Scope.
           exercise the Licensed Rights in the Licensed Material to:
 
             a. reproduce and Share the Licensed Material, in whole or
-               in part, for NonCommercial purposes only; and
+               in part; and
 
-            b. produce, reproduce, and Share Adapted Material for
-               NonCommercial purposes only.
+            b. produce, reproduce, and Share Adapted Material.
 
        2. Exceptions and Limitations. For the avoidance of doubt, where
           Exceptions and Limitations apply to Your use, this Public
@@ -235,9 +220,7 @@ Section 2 -- Scope.
           Rights, whether directly or through a collecting society
           under any voluntary or waivable statutory or compulsory
           licensing scheme. In all other cases the Licensor expressly
-          reserves any right to collect such royalties, including when
-          the Licensed Material is used other than for NonCommercial
-          purposes.
+          reserves any right to collect such royalties.
 
 
 Section 3 -- License Conditions.
@@ -282,6 +265,7 @@ following conditions.
           reasonable to satisfy the conditions by providing a URI or
           hyperlink to a resource that includes the required
           information.
+
        3. If requested by the Licensor, You must remove any of the
           information required by Section 3(a)(1)(A) to the extent
           reasonably practicable.
@@ -293,7 +277,7 @@ following conditions.
 
        1. The Adapter's License You apply must be a Creative Commons
           license with the same License Elements, this version or
-          later, or a BY-NC-SA Compatible License.
+          later, or a BY-SA Compatible License.
 
        2. You must include the text of, or the URI or hyperlink to, the
           Adapter's License You apply. You may satisfy this condition
@@ -313,8 +297,7 @@ apply to Your use of the Licensed Material:
 
   a. for the avoidance of doubt, Section 2(a)(1) grants You the right
      to extract, reuse, reproduce, and Share all or a substantial
-     portion of the contents of the database for NonCommercial purposes
-     only;
+     portion of the contents of the database;
 
   b. if You include all or a substantial portion of the database
      contents in a database in which You have Sui Generis Database
@@ -421,23 +404,24 @@ Section 8 -- Interpretation.
      that apply to the Licensor or You, including from the legal
      processes of any jurisdiction or authority.
 
+
 =======================================================================
 
-Creative Commons is not a party to its public
-licenses. Notwithstanding, Creative Commons may elect to apply one of
-its public licenses to material it publishes and in those instances
-will be considered the â€œLicensor.â€ The text of the Creative Commons
-public licenses is dedicated to the public domain under the CC0 Public
-Domain Dedication. Except for the limited purpose of indicating that
-material is shared under a Creative Commons public license or as
-otherwise permitted by the Creative Commons policies published at
+Creative Commons is not a party to its public licenses.
+Notwithstanding, Creative Commons may elect to apply one of its public
+licenses to material it publishes and in those instances will be
+considered the “Licensor.” The text of the Creative Commons public
+licenses is dedicated to the public domain under the CC0 Public Domain
+Dedication. Except for the limited purpose of indicating that material
+is shared under a Creative Commons public license or as otherwise
+permitted by the Creative Commons policies published at
 creativecommons.org/policies, Creative Commons does not authorize the
 use of the trademark "Creative Commons" or any other trademark or logo
 of Creative Commons without its prior written consent including,
 without limitation, in connection with any unauthorized modifications
 to any of its public licenses or any other arrangements,
 understandings, or agreements concerning use of licensed material. For
-the avoidance of doubt, this paragraph does not form part of the
-public licenses.
+the avoidance of doubt, this paragraph does not form part of the public
+licenses.
 
 Creative Commons may be contacted at creativecommons.org.

--- a/site/index.html
+++ b/site/index.html
@@ -34,7 +34,5 @@
         | <a href="https://github.com/www-learn-study/saraswati.learn.study/commits/main">CHANGES</a>
         | <a href="http://minecraft.learn.study/">Minecraft OASIS</a>
     </p>
-
-    <p xmlns:cc="http://creativecommons.org/ns#" xmlns:dct="http://purl.org/dc/terms/"><a property="dct:title" rel="cc:attributionURL" href="https://www.learn.study">Learn.study</a> is licensed under <a href="http://creativecommons.org/licenses/by-nc-sa/4.0/?ref=chooser-v1" target="_blank" rel="license noopener noreferrer" style="display:inline-block;">CC BY-NC-SA 4.0<img style="height:22px!important;margin-left:3px;vertical-align:text-bottom;" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg?ref=chooser-v1"><img style="height:22px!important;margin-left:3px;vertical-align:text-bottom;" src="https://mirrors.creativecommons.org/presskit/icons/by.svg?ref=chooser-v1"><img style="height:22px!important;margin-left:3px;vertical-align:text-bottom;" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg?ref=chooser-v1"><img style="height:22px!important;margin-left:3px;vertical-align:text-bottom;" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg?ref=chooser-v1"></a></p>
   </body>
 </html>


### PR DESCRIPTION
This reverts commit efd19cc77ace664de8e72d637ffa18f142017053, after
I have done some research about CC BY-NC-SA 4.0 -vs- its BY-SA.

Reading https://github.com/github/choosealicense.com/blob/gh-pages/CONTRIBUTING.md#adding-a-license
and better understanding that BY-NC-SA is neither OSI nor GNU approved,
nor https://opendefinition.org/licenses/, and learning:

https://www.gnu.org/licenses/license-list.en.html#NonFreeDocumentationLicenses:
"In addition, it has a drawback for any sort of work: when a modified version has many authors,
in practice getting permission for commercial use from all of them would become infeasible."

Also e.g. see:

* https://github.com/github/choosealicense.com/pull/471
* https://github.com/github/choosealicense.com/issues/1020
* https://github.com/licensee/licensee/issues/343

PS: The CC BY-NC-SA 4.0 isn't "invalid", of course; and according to
https://github.com/search?q=%22Creative+Commons+Attribution+Non+Commercial+Share+Alike+4.0%22+International+&type=code
~ 1.3k files do use it (which is not a lot, at GitHub scale); I just choose
not to use it for this project, after having researched and learnt more.