### PR TITLE
Revert "build: Preview deployments: false"

### DIFF
--- a/.github/workflows/preview.yaml
+++ b/.github/workflows/preview.yaml
@@ -66,8 +66,6 @@ jobs:
       - uses: vorburger/pages-preview@a5d03757567f1de500903d9cf7e35c99a7514d69
         with:
           build_dir: site
-          # https://github.com/EndBug/pages-preview/issues/20
-          deployments: false
           preview_base_url: ${{ env.PAGES_BASE }}
           preview_repo: ${{ env.PREVIEW_REPO }}
           preview_token: ${{ secrets.PREVIEW_TOKEN }}


### PR DESCRIPTION
Reverts www-learn-study/saraswati.learn.study#34

To test, after this is merged, via https://github.com/www-learn-study/saraswati.learn.study/pull/35, if after #36 for https://github.com/EndBug/pages-preview/pull/21 for https://github.com/EndBug/pages-preview/issues/20 the Deployment Comment perhaps work now.