### PR TITLE
Revert "Revert "build: Preview deployments: false (#34)""

### DIFF
--- a/.github/workflows/preview.yaml
+++ b/.github/workflows/preview.yaml
@@ -66,6 +66,8 @@ jobs:
       - uses: vorburger/pages-preview@a5d03757567f1de500903d9cf7e35c99a7514d69
         with:
           build_dir: site
+          # https://github.com/EndBug/pages-preview/issues/20
+          deployments: false
           preview_base_url: ${{ env.PAGES_BASE }}
           preview_repo: ${{ env.PREVIEW_REPO }}
           preview_token: ${{ secrets.PREVIEW_TOKEN }}


### PR DESCRIPTION
This reverts commit 9a1271b8aba96adafa6c137e4426a13233cac5ad.

Because that didn't work; see https://github.com/EndBug/pages-preview/pull/21#issuecomment-1789937473.