### PR TITLE
build: Fix Preview GitHub Action Workflow (re. pull_request_target)

### DIFF
--- a/.github/workflows/preview.yaml
+++ b/.github/workflows/preview.yaml
@@ -4,7 +4,7 @@ name: Preview
 on:
   # NOT on push: branches: - 'main'
   # ? delete:
-  pull_request_target:
+  pull_request:
     types:
       - opened
       - reopened


### PR DESCRIPTION
This should hopefully finally fix https://github.com/www-learn-study/saraswati.learn.study/pull/42#issuecomment-1790047185.

See https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request_target