### PR TITLE
Revert "build: Remove redundant confusing Mega Linter permissions"

### DIFF
--- a/.github/workflows/mega-linter.yaml
+++ b/.github/workflows/mega-linter.yaml
@@ -36,11 +36,8 @@ concurrency:
   group: ${{ github.ref }}-${{ github.workflow }}
   cancel-in-progress: true
 
-# https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token
-# NB: The "Maximum access for pull requests from public forked repositories" is still only read, even though we ask for write here;
-# this only applies to branches on the repo itself. This makes sense security wise (committers who you can push to branches, are implictily already "trusted" anyway, as they could merge PRs).
 permissions:
-  contents: write
+  contents: read
   pull-requests: write
   issues: write
 
@@ -48,6 +45,13 @@ jobs:
   megalinter:
     name: MegaLinter
     runs-on: ubuntu-latest
+
+    # Give the default GITHUB_TOKEN write permission to commit and push, comment
+    # issues, and post new Pull Requests; remove the ones you do not need
+    permissions:
+      contents: write
+      issues: write
+      pull-requests: write
 
     steps:
       # Git Checkout


### PR DESCRIPTION
Reverts www-learn-study/saraswati.learn.study#28

because of https://github.com/www-learn-study/saraswati.learn.study/issues/50#issuecomment-1790165711