### PR TITLE
build: Use pr-preview-action @v1.4.4 instead of SHA

### DIFF
--- a/.github/workflows/preview.yaml
+++ b/.github/workflows/preview.yaml
@@ -46,7 +46,7 @@ jobs:
         # https://github.com/www-learn-study/saraswati.learn.study/issues/50
         if: steps.changes.outputs.workflows == 'false'
         # TODO Re-check if https://github.com/actions/deploy-pages#inputs- support of "preview" is no longer "only in alpha currently and is not available to the public"
-        uses: rossjrw/pr-preview-action@183082fd714654433c8e2f6daedbfb4f20f2a94a # v1.4.4
+        uses: rossjrw/pr-preview-action@v1.4.4
         with:
           source-dir: BUILT/site/
           # https://github.com/www-learn-study/previews


### PR DESCRIPTION
Was this change I made in https://github.com/www-learn-study/saraswati.learn.study/commit/8e058c4460c6582eea099af5e287c0bfac275018 the culprit causing https://github.com/rossjrw/pr-preview-action/issues/67?!